### PR TITLE
Fix footer 2019 webpack text to pin at bottom

### DIFF
--- a/src/client/stylesheets/modules/app.module.scss
+++ b/src/client/stylesheets/modules/app.module.scss
@@ -64,7 +64,6 @@ button:hover {
   display: flex;
   width: 1100px;
   justify-content: space-between;
-  position:fixed;
-  bottom:0;
+  transform: translate(0, 800px);
 }
 


### PR DESCRIPTION
Issue: Footer, 2019 webpack text at the bottom, doesn’t stay pinned to the bottom when you open up the chrome dev tools. It should stay pinned at the bottom of the page how it looks in the mocks instead of coming up to middle of page.

Changed SCSS on .footer
Removed "position: fixed" and "bottom: 0"
Added "transform: translate (0, 800px)"

Shoutout to Ken Lam! :)